### PR TITLE
Update docker files for backend and frontend

### DIFF
--- a/registry/backend/Dockerfile
+++ b/registry/backend/Dockerfile
@@ -5,15 +5,21 @@ WORKDIR /app
 RUN apt update 
 RUN apt install -y build-essential pkg-config libssl-dev cmake 
 
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./src ./src
+COPY ./registry/backend/Cargo.toml ./registry/backend/Cargo.toml
+COPY ./registry/backend/Cargo.lock ./registry/backend/Cargo.lock
+COPY ./registry/backend/src ./registry/backend/src
+COPY ./codegen ./codegen
+
+WORKDIR /app/registry/backend
 
 RUN cargo build --release
 
 FROM rust:1.83-slim
-COPY --from=build /app/target/release/telchar-backend .
+COPY --from=build /app/registry/backend/target/release/telchar-backend /app/bin/telchar-backend
+COPY ./registry/data /app/data
 
 ENV ROCKET_ADDRESS=0.0.0.0
+
+WORKDIR /app/bin
 
 CMD ["./telchar-backend"]

--- a/registry/frontend/Dockerfile
+++ b/registry/frontend/Dockerfile
@@ -3,23 +3,23 @@ RUN npm i -g pnpm
 COPY . /app
 
 FROM dependencies-env AS development-dependencies-env
-COPY ./package.json pnpm-lock.yaml /app/
+COPY ./package.json ./pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm i --frozen-lockfile
 
 FROM dependencies-env AS production-dependencies-env
-COPY ./package.json pnpm-lock.yaml /app/
+COPY ./package.json ./pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm i --prod --frozen-lockfile --ignore-scripts
 
 FROM dependencies-env AS build-env
-COPY ./package.json pnpm-lock.yaml /app/
+COPY ./package.json ./pnpm-lock.yaml /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
 RUN pnpm build
 
 FROM dependencies-env
-COPY ./package.json pnpm-lock.yaml server.js /app/
+COPY ./package.json ./pnpm-lock.yaml ./server.js /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/build /app/build
 WORKDIR /app


### PR DESCRIPTION
From root folder, now is possible to build Docker images for backend and frontend without any issues.

For backend, I run this command
```bash
docker build --platform linux/amd64 --tag telchar-backend:latest -f registry/backend/Dockerfile .
```
As this needs to include codegen as dependency (maybe we can improve this?)

For frontend, I run this command
```bash
docker build --platform linux/amd64 --tag telchar-frontend:latest registry/frontend
``` 